### PR TITLE
Bump chrome container version to 102 to enable linux/arm64 support on it

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - redis:/data
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:100
+    image: gcr.io/zenika-hub/alpine-chrome:102
     restart: unless-stopped
     command:
       - --no-sandbox

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - redis:/data
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:102
+    image: gcr.io/zenika-hub/alpine-chrome:123
     restart: unless-stopped
     command:
       - --no-sandbox

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - redis:/data
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:100
+    image: gcr.io/zenika-hub/alpine-chrome:102
     restart: unless-stopped
     command:
       - --no-sandbox

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - redis:/data
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:102
+    image: gcr.io/zenika-hub/alpine-chrome:123
     restart: unless-stopped
     command:
       - --no-sandbox


### PR DESCRIPTION
Necessary context: https://github.com/MohamedBassem/hoarder-app/issues/42

Changes the chrome container version in docker-compose from 100 to 102, because version 102 has a `linux/arm64` artifact and it can thus run on ARM architecture.