### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     env_file:
       - .env
     environment:
-      MEILI_NO_ANALYTICS: true
+      MEILI_NO_ANALYTICS: "true"
     volumes:
       - meilisearch:/meili_data
   workers:


### PR DESCRIPTION
fix: solve invalid type of services.meilisearch.environment.MEILI_NO_ANALYTICS

problem description:
when you run 
`docker-compose up`

it shows:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.meilisearch.environment.MEILI_NO_ANALYTICS contains true, which is an invalid type, it should be a string, number, or a null
```