### PR TITLE
feature: Clicking preview for image assets brings up the details modal

### DIFF
--- a/apps/web/components/dashboard/bookmarks/AssetCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/AssetCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { api } from "@/lib/trpc";
 
 import type {
@@ -23,12 +24,14 @@ function AssetImage({
   switch (bookmarkedAsset.assetType) {
     case "image": {
       return (
-        <Image
-          alt="asset"
-          src={getAssetUrl(bookmarkedAsset.assetId)}
-          fill={true}
-          className={className}
-        />
+        <Link href={`/dashboard/preview/${bookmark.id}`}>
+          <Image
+            alt="asset"
+            src={getAssetUrl(bookmarkedAsset.assetId)}
+            fill={true}
+            className={className}
+          />
+        </Link>
       );
     }
     case "pdf": {


### PR DESCRIPTION
Hi there! Very simple tweak to make my and my spouse's lives a bit easier--as designers, we make heavy use of the ability to save images in Hoarder!

By default, link bookmarks have a clickable preview image and title, and the maximize button in the action bar opens a modal with the local text-only archive. Uploaded images don't have an external link, so clicking the preview image or title does nothing, and only clicking the maximize button opens the details modal so the full image can be viewed.

This change just makes preview images for image assets open the details modal--the same behavior as the maximize button. Makes them a little easier to hit on mobile 😸

It's my first time working with NextJS, so I hope everything looks okay. Thanks for making Hoarder; we're really enjoying it so far!