### PR TITLE
feature(web): Clicking an image in the preview modal will open it in a new tab

### DIFF
--- a/apps/web/components/dashboard/preview/AssetContentSection.tsx
+++ b/apps/web/components/dashboard/preview/AssetContentSection.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import type { ZBookmark } from "@hoarder/shared/types/bookmarks";
 
@@ -11,12 +12,17 @@ export function AssetContentSection({ bookmark }: { bookmark: ZBookmark }) {
     case "image": {
       return (
         <div className="relative h-full min-w-full">
-          <Image
-            alt="asset"
-            fill={true}
-            className="object-contain"
-            src={`/api/assets/${bookmark.content.assetId}`}
-          />
+          <Link
+            href={`/api/assets/${bookmark.content.assetId}`}
+            target="_blank"
+          >
+            <Image
+              alt="asset"
+              fill={true}
+              className="object-contain"
+              src={`/api/assets/${bookmark.content.assetId}`}
+            />
+          </Link>
         </div>
       );
     }


### PR DESCRIPTION
My husband gave me the idea for this PR 😉 As part of his illustration work, he saves a lot of images for drawing reference, and it's helpful to be able to open them in a split view on his iPad so he can have his reference right next to the canvas. Unfortunately, the pinch-to-zoom gesture doesn't work on images when Hoarder is added to the Home Screen as a web app. This tweak just links the image in the preview modal to the original file, so clicking it will open it in a new tab that can be zoomed, panned, etc.

(Side note: I originally had a much more complicated implementation for this, with a toggle for fullscreen mode and a pinch-pan-zoom library for manipulating the image when fullscreened. But, as it turns out, Apple hasn't made the Fullscreen API available for browsers other than iPad Safari. I couldn't figure out an alternative solution for unsupported browsers, so I ended up scrapping the whole thing. Opening the original image into a new tab is what Raindrop.io does, and that's what we're aiming to replace with Hoarder, so that's the change I ended up making. Hopefully it works well enough, but I'd be curious to hear your thoughts!)