### PR TITLE
ui(web): Various tweaks for input fields in preview modal

### DIFF
--- a/apps/web/components/dashboard/bookmarks/TagsEditor.tsx
+++ b/apps/web/components/dashboard/bookmarks/TagsEditor.tsx
@@ -120,13 +120,31 @@ export function TagsEditor({ bookmark }: { bookmark: ZBookmark }) {
           overflowY: "auto",
           scrollbarWidth: "none",
         }),
+        container: (styles) => ({
+          ...styles,
+          width: "100%",
+        }),
         control: (styles) => ({
           ...styles,
+          overflow: "hidden",
           backgroundColor: "hsl(var(--background))",
           borderColor: "hsl(var(--border))",
           ":hover": {
             borderColor: "hsl(var(--border))",
           },
+        }),
+        input: (styles) => ({
+          ...styles,
+          color: "rgb(156 163 175)",
+        }),
+        menu: (styles) => ({
+          ...styles,
+          overflow: "hidden",
+          color: "rgb(156 163 175)",
+        }),
+        placeholder: (styles) => ({
+          ...styles,
+          color: "hsl(var(--muted-foreground))",
         }),
       }}
       components={{
@@ -155,9 +173,11 @@ export function TagsEditor({ bookmark }: { bookmark: ZBookmark }) {
       }}
       classNames={{
         multiValueRemove: () => "my-auto",
-        valueContainer: () => "gap-2 bg-background",
-        menuList: () => "text-sm bg-background",
+        valueContainer: () => "gap-2 bg-background text-sm",
+        menu: () => "dark:text-gray-300",
+        menuList: () => "bg-background text-sm",
         option: () => "text-red-500",
+        input: () => "dark:text-gray-300",
       }}
     />
   );

--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -133,12 +133,12 @@ export default function BookmarkPreview({
         </div>
 
         <CreationTime createdAt={bookmark.createdAt} />
-        <div className="flex gap-4">
+        <div className="flex items-center gap-4">
           <p className="text-sm text-gray-400">Tags</p>
           <TagsEditor bookmark={bookmark} />
         </div>
         <div className="flex gap-4">
-          <p className="text-sm text-gray-400">Note</p>
+          <p className="pt-2 text-sm text-gray-400">Note</p>
           <NoteEditor bookmark={bookmark} />
         </div>
         <ActionBar bookmark={bookmark} />


### PR DESCRIPTION
Another fresh batch of styles from me today! 🧑‍🍳

- Set the tag input field to 100% width to fix an issue where the tag select dropdown could overflow when inputting short sections of text.

![Screenshot 2024-05-18 at 9 24 19 PM](https://github.com/MohamedBassem/hoarder-app/assets/44416326/24bca10e-4af7-439d-b701-202d6ba77fbf)

- Fixed an issue where the corners of the tag input field and select dropdown did not match the corners of the note field. (Below image shows the issue at 400% zoom.)

![Screenshot 2024-05-18 at 1 02 34 PM](https://github.com/MohamedBassem/hoarder-app/assets/44416326/3b81eae7-573a-4140-b414-fd5782c224c1)

- Changed some styles to align labels to their respective fields and make field contents more visually consistent (text size, colors, etc).

![Screenshot 2024-05-18 at 9 14 40 PM](https://github.com/MohamedBassem/hoarder-app/assets/44416326/cf9af0bd-f757-4b0b-849f-b9ad2fa591e3)
