### PR TITLE
bookmark list output is not a valid JSON #150

### DIFF
--- a/apps/cli/src/commands/bookmarks.ts
+++ b/apps/cli/src/commands/bookmarks.ts
@@ -136,7 +136,7 @@ bookmarkCmd
       results = [...results, ...resp.bookmarks];
     }
 
-    console.dir(results.map(normalizeBookmark), { maxArrayLength: null });
+    console.log(JSON.stringify(results.map(normalizeBookmark), null, 4));
   });
 
 bookmarkCmd


### PR DESCRIPTION
fixed the encoding issue by using json.stringify to get parsable JSON